### PR TITLE
add getCommuncator to do queries before selecting a database

### DIFF
--- a/database/include/mainframe/database/mysql/communicator.h
+++ b/database/include/mainframe/database/mysql/communicator.h
@@ -24,7 +24,7 @@ namespace mainframe {
 			std::string lastError;
 			std::mutex lock;
 
-			Result execute(const std::string& query, DatabaseMysql* db);
+			Result execute(const std::string& query, DatabaseMysql* db = nullptr);
 
 			bool fail(const std::string& err);
 			bool fail(const std::string& err, const std::string& title);

--- a/database/include/mainframe/database/mysql/connection.h
+++ b/database/include/mainframe/database/mysql/connection.h
@@ -50,6 +50,7 @@ namespace mainframe {
 
 			virtual std::vector<std::string> listDatabases() override;
 			virtual std::shared_ptr<Database> getDatabase(const std::string& name) override;
+			std::shared_ptr<Communicator> getCommunicator() const;
 
 			virtual const std::string& getLastError() const override;
 

--- a/database/src/mysql/connection.cpp
+++ b/database/src/mysql/connection.cpp
@@ -12,6 +12,10 @@ namespace mainframe {
 			return communicator->getLastError();
 		}
 
+		std::shared_ptr<Communicator> ConnectionMysql::getCommunicator() const {
+			return communicator;
+		}
+
 		bool ConnectionMysql::connect(const std::string& ip, int port, const std::string& user, const std::string& pass) {
 			Connection::connect(ip, port, user, pass);
 


### PR DESCRIPTION
Currently working on a migrator tool which needs to be able to check if a database exists, if not, create it.