### PR TITLE
fix onResize not being called and viewport to match window size

### DIFF
--- a/game/src/window.cpp
+++ b/game/src/window.cpp
@@ -20,6 +20,8 @@ namespace mainframe {
 		}
 
 		void Window::callbacks_resize(GLFWwindow* whandle, int width, int height) {
+			glViewport(0, 0, width, height);
+
 			auto& window = glfwHandleToWindow(whandle);
 			window.onResize(window, {width, height});
 		}
@@ -82,6 +84,7 @@ namespace mainframe {
 		}
 
 		void Window::addOnResize(OnResizeCallback::Func callback) {
+			onResize += callback;
 		}
 
 		void Window::addOnChar(OnCharCallback::Func callback) {


### PR DESCRIPTION
When the window is resized by code, the viewport messes up and renders with the old sizes.
OnResize also wasn't called inside the window object from the GLFW event.