### PR TITLE
Minor memory optimization for fonts

### DIFF
--- a/render/src/font.cpp
+++ b/render/src/font.cpp
@@ -49,6 +49,7 @@ namespace mainframe {
 			}
 
 			tex.upload();
+			tex.unloadPixels();
 		}
 
 		const ftgl::texture_glyph_t* Font::getGlyph(uint32_t character) const {

--- a/render/src/texture.cpp
+++ b/render/src/texture.cpp
@@ -69,7 +69,7 @@ namespace mainframe {
 			std::vector<Color> newpixels;
 			newpixels.resize(newsize.y * newsize.x);
 
-			if (size.x > 0 && size.y > 0) {
+			if (!pixels.empty() && size.x > 0 && size.y > 0) {
 				auto wperc = static_cast<float>(newsize.x) / static_cast<float>(size.x);
 				auto hperc = static_cast<float>(newsize.y) / static_cast<float>(size.y);
 


### PR DESCRIPTION
After we loaded a font, we have no reason to keep the pixels in memory. We can unload these.
Also fixed a bug where resizing an unloaded texture would crash.