### PR TITLE
Add scene::getFocus and scene::setFocus(element)

### DIFF
--- a/game/src/window.cpp
+++ b/game/src/window.cpp
@@ -411,6 +411,9 @@ namespace mainframe {
 			glEnable(GL_BLEND);
 			glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
+			// when a window is created it gains focus from the window manager
+			hasFocus = true;
+
 			return true;
 		}
 	}

--- a/ui/include/mainframe/ui/scene.h
+++ b/ui/include/mainframe/ui/scene.h
@@ -48,6 +48,9 @@ namespace mainframe {
 
 			void setWindow(game::Window& window);
 
+			std::shared_ptr<Element> getFocus();
+			void setFocus(std::shared_ptr<Element> elm);
+
 			static std::shared_ptr<Scene> create();
 		};
 	}

--- a/ui/src/scene.cpp
+++ b/ui/src/scene.cpp
@@ -11,6 +11,15 @@ namespace mainframe {
 			return ret;
 		}
 
+		std::shared_ptr<Element> Scene::getFocus() {
+			if (focusedElement.expired()) return {};
+			return focusedElement.lock();
+		}
+
+		void Scene::setFocus(std::shared_ptr<Element> elm) {
+			focusedElement = elm;
+		}
+
 		void Scene::setWindow(game::Window& window) {
 			setPos(0);
 			setSize(window.getSize());


### PR DESCRIPTION
Also fixes bug where window was not marked focused when it is first created