### PR TITLE
Fixes conan file dir and MSVC 17 version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,13 +7,13 @@ project ("mainframe" VERSION ${MAINFRAME_VERSION})
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSPDLOG_FMT_EXTERNAL -DNOMINMAX")
 
-if(NOT EXISTS "${CMAKE_BINARY_DIR}/conan.cmake")
+if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/conan.cmake")
    message(STATUS "Downloading conan.cmake from https://github.com/conan-io/cmake-conan")
    file(DOWNLOAD "https://raw.githubusercontent.com/conan-io/cmake-conan/master/conan.cmake"
                   "${CMAKE_BINARY_DIR}/conan.cmake")
 endif()
 
-include(${CMAKE_BINARY_DIR}/conan.cmake)
+include(${CMAKE_CURRENT_BINARY_DIR}/conan.cmake)
 
 if(CMAKE_COMPILER_IS_GNUXX)
    set(CONAN_SETTINGS compiler.libcxx=libstdc++11)
@@ -23,7 +23,7 @@ conan_cmake_run(CONANFILE conanfile.txt
                 SETTINGS ${CONAN_SETTINGS}
                 BUILD missing)
 
-include(${CMAKE_BINARY_DIR}/conan_paths.cmake)
+include(${CMAKE_CURRENT_BINARY_DIR}/conan_paths.cmake)
 
 find_package(glfw3 REQUIRED)
 find_package(GLEW REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSPDLOG_FMT_EXTERNAL -DNOMINMAX")
 
 if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/conan.cmake")
    message(STATUS "Downloading conan.cmake from https://github.com/conan-io/cmake-conan")
-   file(DOWNLOAD "https://gist.githubusercontent.com/Bromvlieg/eb8564c44726fd985f3c26d929d2f1f3/raw/1d79995a9e6359e5e98499b268ea53850fbbf088/conan.cmake"
+   file(DOWNLOAD "https://raw.githubusercontent.com/conan-io/cmake-conan/master/conan.cmake"
                   "${CMAKE_CURRENT_BINARY_DIR}/conan.cmake")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSPDLOG_FMT_EXTERNAL -DNOMINMAX")
 
 if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/conan.cmake")
    message(STATUS "Downloading conan.cmake from https://github.com/conan-io/cmake-conan")
-   file(DOWNLOAD "https://raw.githubusercontent.com/conan-io/cmake-conan/master/conan.cmake"
-                  "${CMAKE_BINARY_DIR}/conan.cmake")
+   file(DOWNLOAD "https://gist.githubusercontent.com/Bromvlieg/eb8564c44726fd985f3c26d929d2f1f3/raw/1d79995a9e6359e5e98499b268ea53850fbbf088/conan.cmake"
+                  "${CMAKE_CURRENT_BINARY_DIR}/conan.cmake")
 endif()
 
 include(${CMAKE_CURRENT_BINARY_DIR}/conan.cmake)

--- a/database/CMakeLists.txt
+++ b/database/CMakeLists.txt
@@ -8,7 +8,7 @@
 set(output_target mainframe.database)
 add_library(${output_target} ${source_files})
 target_include_directories(${output_target} PUBLIC "include")
-target_compile_features(${output_target} PRIVATE cxx_std_20)
+target_compile_features(${output_target} PUBLIC cxx_std_20)
 target_link_libraries(${output_target} PUBLIC fmt::fmt mainframe.networking)
 
 if (build_tests)

--- a/game/CMakeLists.txt
+++ b/game/CMakeLists.txt
@@ -8,7 +8,7 @@
 set(output_target mainframe.game)
 add_library(${output_target} ${source_files})
 target_include_directories(${output_target} PUBLIC "include")
-target_compile_features(${output_target} PRIVATE cxx_std_20)
+target_compile_features(${output_target} PUBLIC cxx_std_20)
 
 
 if (WIN32)

--- a/math/CMakeLists.txt
+++ b/math/CMakeLists.txt
@@ -10,7 +10,7 @@ set(output_target mainframe.math)
 add_library(${output_target} ${source_files})
 target_include_directories(${output_target} PUBLIC "include")
 target_link_libraries(${output_target} PUBLIC glm::glm)
-target_compile_features(${output_target} PRIVATE cxx_std_20)
+target_compile_features(${output_target} PUBLIC cxx_std_20)
 
 if (build_tests)
 	add_subdirectory("tests")

--- a/networking/CMakeLists.txt
+++ b/networking/CMakeLists.txt
@@ -8,7 +8,7 @@
 set(output_target mainframe.networking)
 add_library(${output_target} ${source_files})
 target_include_directories(${output_target} PUBLIC "include")
-target_compile_features(${output_target} PRIVATE cxx_std_20)
+target_compile_features(${output_target} PUBLIC cxx_std_20)
 
 if (build_tests)
 	add_subdirectory("tests")

--- a/render/CMakeLists.txt
+++ b/render/CMakeLists.txt
@@ -9,7 +9,7 @@
 set(output_target mainframe.render)
 add_library(${output_target} ${source_files})
 target_include_directories(${output_target} PUBLIC "include")
-target_compile_features(${output_target} PRIVATE cxx_std_20)
+target_compile_features(${output_target} PUBLIC cxx_std_20)
 
 target_link_libraries(${output_target} PUBLIC mainframe.math ${mf_winlibs} GLEW::GLEW fmt::fmt lodepng::lodepng Freetype::Freetype utf8cpp)
 

--- a/ui/CMakeLists.txt
+++ b/ui/CMakeLists.txt
@@ -8,7 +8,7 @@
 set(output_target mainframe.ui)
 add_library(${output_target} ${source_files})
 target_include_directories(${output_target} PUBLIC "include")
-target_compile_features(${output_target} PRIVATE cxx_std_20)
+target_compile_features(${output_target} PUBLIC cxx_std_20)
 target_link_libraries(${output_target} PUBLIC mainframe.game ${mf_winlibs} ${mf_ui_libs} mainframe.utils mainframe.render mainframe.math)
 
 if (build_tests)


### PR DESCRIPTION
- Conan needs to write it's files to the `CURRENT` binary dir, not the global end product one.
- Windows MSVC 17 (2022) version is not added to official Conan repo...........?