### PR TITLE
make Label::getFont() return a non-const

### DIFF
--- a/ui/include/mainframe/ui/elms/label.h
+++ b/ui/include/mainframe/ui/elms/label.h
@@ -23,7 +23,7 @@ namespace mainframe {
 
 			const render::Color getColor();
 			const std::string& getText();
-			render::Font* getFont( );
+			render::Font* getFont();
 			render::Stencil::TextAlignment getAlignmentX();
 			render::Stencil::TextAlignment getAlignmentY();
 

--- a/ui/include/mainframe/ui/elms/label.h
+++ b/ui/include/mainframe/ui/elms/label.h
@@ -23,7 +23,7 @@ namespace mainframe {
 
 			const render::Color getColor();
 			const std::string& getText();
-			const render::Font* getFont( );
+			render::Font* getFont( );
 			render::Stencil::TextAlignment getAlignmentX();
 			render::Stencil::TextAlignment getAlignmentY();
 

--- a/ui/src/elms/label.cpp
+++ b/ui/src/elms/label.cpp
@@ -33,7 +33,7 @@ namespace mainframe {
 			return text;
 		}
 
-		const render::Font* Label::getFont() {
+		render::Font* Label::getFont() {
 			return font;
 		}
 


### PR DESCRIPTION
We need access to the `Font::addChars` method which modifies private `glyphs`.