### PR TITLE
fix input not being executed on scene thread

### DIFF
--- a/ui/include/mainframe/ui/element.h
+++ b/ui/include/mainframe/ui/element.h
@@ -59,7 +59,7 @@ namespace mainframe {
 			bool isfocused();
 			virtual void setFocused(bool focused_);
 
-			void invoke(std::function<void()> func);
+			void invoke(std::function<void()> func, bool forceQueue = false);
 
 			virtual bool hitTest(const math::Vector2i& mousePos);
 			virtual void mouseDown(const math::Vector2i& mousePos, unsigned int button, ModifierKey mods);

--- a/ui/include/mainframe/ui/scene.h
+++ b/ui/include/mainframe/ui/scene.h
@@ -43,7 +43,7 @@ namespace mainframe {
 			mainframe::utils::Event<unsigned int> onKeyChar;
 
 			utils::ringbuffer<std::function<void()>>& getInvoker();
-			void invoke(std::function<void()> func);
+			void invoke(std::function<void()> func, bool forceQueue = false);
 
 			void draw(render::Stencil& stencil);
 			void update(float deltaTime);

--- a/ui/src/element.cpp
+++ b/ui/src/element.cpp
@@ -19,14 +19,13 @@ namespace mainframe {
 			return invokes;
 		}
 
-		void Element::invoke(std::function<void()> func) {
-			// if we're on the same thread, dont queue it
-			if (getThreadId() == std::this_thread::get_id()) {
-				func();
+		void Element::invoke(std::function<void()> func, bool forceQueue) {
+			if (forceQueue || getThreadId() != std::this_thread::get_id()) {
+				invokes.push(func);
 				return;
 			}
 
-			invokes.push(func);
+			func();
 		}
 
 		void Element::setHovering(bool hovering_) {


### PR DESCRIPTION
When using more than 1 window the scene will throw errors about accessing things on the wrong thread.
All input by GLFW gets handled by 1 thread. So input needs to be invoked on the Scene to switch to the correct thread