### PR TITLE
add unload & init functions for TextEngine

### DIFF
--- a/render/include/mainframe/render/textengine.h
+++ b/render/include/mainframe/render/textengine.h
@@ -10,7 +10,7 @@ namespace mainframe {
 	namespace render {
 		// Not threadsafe, make one engine per thread
 		class TextEngine {
-			FT_Library ft;
+			FT_Library ft = nullptr;
 			std::vector<std::unique_ptr<Font>> faces;
 
 		public:
@@ -23,6 +23,8 @@ namespace mainframe {
 
 			~TextEngine();
 
+			void init();
+			void unload();
 			Font& loadFont(std::string filename, unsigned int size);
 		};
 	}

--- a/render/src/textengine.cpp
+++ b/render/src/textengine.cpp
@@ -6,13 +6,16 @@
 namespace mainframe {
 	namespace render {
 		TextEngine::TextEngine() {
-			if (FT_Init_FreeType(&ft) != 0) {
-				throw std::runtime_error("Error: failed to initialize freetype");
-			}
+			init();
+		}
+
+		void TextEngine::init() {
+			if (ft != nullptr) return;
+			if (FT_Init_FreeType(&ft) != 0) throw std::runtime_error("Error: failed to initialize freetype");
 
 			// FT_LCD_FILTER_LIGHT   is (0x00, 0x55, 0x56, 0x55, 0x00)
 			// FT_LCD_FILTER_DEFAULT is (0x10, 0x40, 0x70, 0x40, 0x10)
-    		unsigned char lcd_weights[5];
+			unsigned char lcd_weights[5];
 			lcd_weights[0] = 0x00;
 			lcd_weights[1] = 0x55;
 			lcd_weights[2] = 0x56;
@@ -23,14 +26,19 @@ namespace mainframe {
 			FT_Library_SetLcdFilterWeights(ft, lcd_weights);
 		}
 
-		TextEngine::~TextEngine() {
+		void TextEngine::unload() {
+			if (ft == nullptr) return;
+
 			// Clear faces now so they can clean up before the freetype library
 			// is cleaned up.
 			faces.clear();
 
-			if (FT_Done_FreeType(ft) != 0) {
-				fmt::print(stderr, "Error: failed to clean up freetype\n");
-			}
+			if (FT_Done_FreeType(ft) != 0) throw std::runtime_error("Error: failed to clean up freetype");
+			ft = nullptr;
+		}
+
+		TextEngine::~TextEngine() {
+			unload();
 		}
 
 		Font& TextEngine::loadFont(std::string filename, unsigned int size) {


### PR DESCRIPTION
In some cases you want to unload the TextEngine earlier, like in a content manager object.