### PR TITLE
add ipv6 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,19 +10,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Install dependencies
-      run: |
-        sudo apt update
-        sudo apt install build-essential gcc-10 libgl1-mesa-glx libgl1-mesa-dev libglew-dev ninja-build sudo python3-pip libx11-dev libx11-xcb-dev libfontenc-dev libice-dev libsm-dev libxau-dev libxaw7-dev libxcomposite-dev libxcursor-dev libxdamage-dev libxdmcp-dev libxext-dev libxfixes-dev libxft-dev libxi-dev libxinerama-dev libxkbfile-dev libxmu-dev libxmuu-dev libxpm-dev libxrandr-dev libxrender-dev libxres-dev libxss-dev libxt-dev libxtst-dev libxv-dev libxvmc-dev libxxf86vm-dev xtrans-dev libxcb-render0-dev libxcb-render-util0-dev libxcb-xkb-dev libxcb-icccm4-dev libxcb-image0-dev libxcb-keysyms1-dev libxcb-randr0-dev libxcb-shape0-dev libxcb-sync-dev libxcb-xfixes0-dev libxcb-xinerama0-dev xkb-data libxcb-dri3-dev uuid-dev libxcb-util-dev
-        sudo pip install conan
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install build-essential gcc-10 libgl1-mesa-glx libgl1-mesa-dev libglew-dev ninja-build sudo python3-pip libx11-dev libx11-xcb-dev libfontenc-dev libice-dev libsm-dev libxau-dev libxaw7-dev libxcomposite-dev libxcursor-dev libxdamage-dev libxdmcp-dev libxext-dev libxfixes-dev libxft-dev libxi-dev libxinerama-dev libxkbfile-dev libxmu-dev libxmuu-dev libxpm-dev libxrandr-dev libxrender-dev libxres-dev libxss-dev libxt-dev libxtst-dev libxv-dev libxvmc-dev libxxf86vm-dev xtrans-dev libxcb-render0-dev libxcb-render-util0-dev libxcb-xkb-dev libxcb-icccm4-dev libxcb-image0-dev libxcb-keysyms1-dev libxcb-randr0-dev libxcb-shape0-dev libxcb-sync-dev libxcb-xfixes0-dev libxcb-xinerama0-dev xkb-data libxcb-dri3-dev uuid-dev libxcb-util-dev
+          sudo pip install conan
 
-    - name: Build
-      run: |
-        mkdir build
-        cd build
-        CXX=g++-10 cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release
-        ninja
+      - name: Install Conan packages
+        run: conan install . -c tools.system.package_manager:mode=install -c tools.system.package_manager:sudo=True
+
+      - name: Build
+        run: |
+          mkdir build
+          cd build
+          CXX=g++-10 cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release
+          ninja
 
     # TODO probably run the tests

--- a/networking/include/mainframe/networking/socket.h
+++ b/networking/include/mainframe/networking/socket.h
@@ -14,6 +14,7 @@
 #ifdef _MSC_VER
 #define _WINSOCKAPI_
 #include <winsock2.h>
+#include <ws2tcpip.h>
 #else
 #include <netinet/in.h>
 #endif
@@ -35,9 +36,12 @@ namespace mainframe {
 			};
 
 			bool blocking = true;
+			bool ipv6 = false;
 
 			sockaddr_in addr;
 			sockaddr_in fromAddr;
+			sockaddr_in6 addr6;
+			sockaddr_in6 fromAddr6;
 			unsigned long fromAddr_len = 0;
 
 			SockState state = SockState::skDISCONNECTED;
@@ -45,7 +49,7 @@ namespace mainframe {
 
 			int lastCode = 0;
 
-			Socket();
+			Socket(bool ipv6 = false);
 			~Socket();
 
 			bool create();
@@ -59,6 +63,8 @@ namespace mainframe {
 
 			uint64_t uAddr();
 			bool isError();
+
+			std::string getIpAddress();
 
 			bool canRead();
 


### PR DESCRIPTION
Changes mainframe Socket logic to support IPV6 hosting.
When connecting to a hostname, it will detect the AF_NET type and switch accordingly.