### PR TITLE
fix recording using invalid offset at vertice moddifier

### DIFF
--- a/render/src/stencil.cpp
+++ b/render/src/stencil.cpp
@@ -578,7 +578,7 @@ namespace mainframe::render {
 			setShader(chunk.shader);
 			setTexture(chunk.texture);
 
-			auto verticeOffset = static_cast<unsigned int>(indices.size());
+			auto verticeOffset = static_cast<unsigned int>(vertices.size());
 			vertices.insert(vertices.end(), chunk.vertices.begin(), chunk.vertices.end());
 
 			size_t incideOffset = indices.size();


### PR DESCRIPTION
When drawing a recording generated from the `Stencil` class, it needs to offset the indices with the already existing amount of vertices.

The current implementation is using `indices.size()` instead of `vertices.size()` and thus effectively drawing complete gibberish if the stencil buffer is not empty before drawing a recording.