### PR TITLE
fix datatype typo for unsigned long

### DIFF
--- a/database/include/mainframe/database/base/value.h
+++ b/database/include/mainframe/database/base/value.h
@@ -27,7 +27,7 @@ namespace mainframe {
 			operator unsigned int() const { return isNull() ? 0 : static_cast<unsigned int>(std::stoul(raw)); }
 
 			operator long() const { return isNull() ? 0 : std::stol(raw); }
-			operator unsigned long() const { return isNull() ? 0 : static_cast<unsigned int>(std::stoul(raw)); }
+			operator unsigned long() const { return isNull() ? 0 : static_cast<unsigned long>(std::stoul(raw)); }
 
 			operator long long() const { return isNull() ? 0 : std::stoll(raw); }
 			operator unsigned long long() const { return isNull() ? 0 : std::stoull(raw); }


### PR DESCRIPTION
There is a typo in the library, the SQL driver uses `unsigned int` as a cast where `unsigned long` is requested as return type