### PR TITLE
add TableInfo to MySQL database connectior

### DIFF
--- a/database/include/mainframe/database/base/row.h
+++ b/database/include/mainframe/database/base/row.h
@@ -18,6 +18,8 @@ namespace mainframe {
 			~Row() = default;
 
 			Row(const std::shared_ptr<std::vector<std::string>>& _columns);
+			const std::shared_ptr<std::vector<std::string>>& getColumns() const;
+			void setColumns(const std::shared_ptr<std::vector<std::string>>& columns);
 
 			bool has(const std::string& key) const;
 			std::vector<std::string>::iterator find(const std::string& key) const;

--- a/database/include/mainframe/database/base/row.h
+++ b/database/include/mainframe/database/base/row.h
@@ -17,9 +17,9 @@ namespace mainframe {
 			Row() = default;
 			~Row() = default;
 
-			Row(const std::shared_ptr<std::vector<std::string>>& _columns);
-			const std::shared_ptr<std::vector<std::string>>& getColumns() const;
-			void setColumns(const std::shared_ptr<std::vector<std::string>>& columns);
+			Row(const std::shared_ptr<std::vector<std::string>> _columns);
+			const std::shared_ptr<std::vector<std::string>> getColumns() const;
+			void setColumns(const std::shared_ptr<std::vector<std::string>> columns);
 
 			bool has(const std::string& key) const;
 			std::vector<std::string>::iterator find(const std::string& key) const;

--- a/database/include/mainframe/database/mysql/database.h
+++ b/database/include/mainframe/database/mysql/database.h
@@ -3,16 +3,28 @@
 #include <string>
 #include <memory>
 #include <mainframe/database/base/database.h>
+#include <mainframe/database/mysql/table.h>
 #include <mainframe/database/mysql/communicator.h>
 
 namespace mainframe {
 	namespace database {
 		class DatabaseMysql : public Database {
 			std::shared_ptr<Communicator> communicator;
+			std::vector<MysqlTable> tables;
+
 
 		public:
+			template<typename... CallbackArgs>
+			Result execute(const std::string& query, CallbackArgs... args) {
+				return execute(fmt::format(query, args...));
+			}
+
 			virtual Result execute(const std::string& query) override;
 			virtual std::vector<std::string> listTables() override;
+
+			const MysqlTable& getTable(const std::string& name);
+			bool hasLoadedTables();
+			void fillTableInfos();
 
 			std::shared_ptr<Communicator> getCommunicator() const;
 			DatabaseMysql(const std::string& name, const std::shared_ptr<Communicator>& _communicator);

--- a/database/include/mainframe/database/mysql/field.h
+++ b/database/include/mainframe/database/mysql/field.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace mainframe {
+	namespace database {
+		struct MysqlField {
+			std::string name;
+			std::string type;
+			bool nullable = false;
+			bool primary = false;
+			std::string defaultValue;
+			std::string extra;
+		};
+	}
+}

--- a/database/include/mainframe/database/mysql/foreignkey.h
+++ b/database/include/mainframe/database/mysql/foreignkey.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace mainframe {
+	namespace database {
+		struct MysqlForeignKey {
+			std::string name;
+			std::string sourceFieldName;
+			std::string sourceTableName;
+			std::string targetFieldName;
+			std::string targetTableName;
+		};
+	}
+}

--- a/database/include/mainframe/database/mysql/table.h
+++ b/database/include/mainframe/database/mysql/table.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <mainframe/database/mysql/foreignkey.h>
+#include <mainframe/database/mysql/field.h>
+
+namespace mainframe {
+	namespace database {
+		struct MysqlTable {
+			std::string name;
+			std::vector<MysqlField> fields;
+			std::vector<MysqlForeignKey> keys;
+		};
+	}
+}

--- a/database/src/base/row.cpp
+++ b/database/src/base/row.cpp
@@ -45,5 +45,13 @@ namespace mainframe {
 		std::vector<std::string>::iterator Row::end() const {
 			return columns->end();
 		}
+
+		const std::shared_ptr<std::vector<std::string>>& Row::getColumns() const {
+			return columns;
+		}
+
+		void Row::setColumns(const std::shared_ptr<std::vector<std::string>>& columns) {
+			this->columns = columns;
+		}
 	}
 }

--- a/database/src/base/row.cpp
+++ b/database/src/base/row.cpp
@@ -4,7 +4,7 @@
 
 namespace mainframe {
 	namespace database {
-		Row::Row(const std::shared_ptr<std::vector<std::string>>& _columns) : columns(_columns) {
+		Row::Row(const std::shared_ptr<std::vector<std::string>> _columns) : columns(_columns) {
 		}
 
 		bool Row::has(const std::string& key) const {
@@ -46,11 +46,11 @@ namespace mainframe {
 			return columns->end();
 		}
 
-		const std::shared_ptr<std::vector<std::string>>& Row::getColumns() const {
+		const std::shared_ptr<std::vector<std::string>> Row::getColumns() const {
 			return columns;
 		}
 
-		void Row::setColumns(const std::shared_ptr<std::vector<std::string>>& columns) {
+		void Row::setColumns(const std::shared_ptr<std::vector<std::string>> columns) {
 			this->columns = columns;
 		}
 	}

--- a/database/src/mysql/communicator.cpp
+++ b/database/src/mysql/communicator.cpp
@@ -266,10 +266,14 @@ namespace mainframe {
 						case MysqlValueType::TINY:
 						case MysqlValueType::BLOB:
 						case MysqlValueType::NEW_DECIMAL:
+						case MysqlValueType::Null:
 							break;
 
 						default:
-							throw std::runtime_error("Warning: unsupported type " + std::to_string(static_cast<int>(type)) + " in column: " + name);
+							// NOTE: if this throws theres 2 cases:
+							// A: you can add it to the list above and not bother with it.
+							// B: you will have to add code that handles that type at the `Field` object
+							throw std::runtime_error("mysql unsupported type " + std::to_string(static_cast<int>(type)) + " in column: " + name);
 					}
 
 					if (!--field)

--- a/database/src/mysql/database.cpp
+++ b/database/src/mysql/database.cpp
@@ -6,6 +6,71 @@ namespace mainframe {
 			return communicator->execute(query, this);
 		}
 
+		void DatabaseMysql::fillTableInfos() {
+			auto lst = listTables();
+			tables.clear();
+
+			for (auto& tableName : lst) {
+				auto resultFields = communicator->execute(fmt::format("DESCRIBE `{}`", tableName), this);
+				auto resultKeys = communicator->execute(fmt::format("SELECT table_name, column_name, constraint_name, referenced_table_name, referenced_column_name FROM information_schema.key_column_usage WHERE table_schema = '{}' AND table_name = '{}'", this->getName(), tableName), this);
+				if (!resultFields.success() || !resultKeys.success()) continue;
+
+				MysqlTable table;
+				table.name = tableName;
+
+				for (auto& fieldInfo : resultFields.rows) {
+					MysqlField field;
+					field.name = fieldInfo["field"].get<std::string>();
+					field.type = fieldInfo["type"].get<std::string>();
+					field.extra = fieldInfo["extra"].get<std::string>();
+					field.defaultValue = fieldInfo["default"].get<std::string>();
+					field.nullable = fieldInfo["null"].get<std::string>() == "YES";
+
+					table.fields.push_back(field);
+				}
+
+				for (auto& keyInfo : resultKeys.rows) {
+					MysqlForeignKey key;
+					key.name = keyInfo["constraint_name"].get<std::string>();
+					key.sourceFieldName = keyInfo["column_name"].get<std::string>();
+					key.sourceTableName = keyInfo["table_name"].get<std::string>();
+
+					if (key.name == "PRIMARY") {
+						auto iter = std::find_if(table.fields.begin(), table.fields.end(), [&](const MysqlField& field) {
+							return field.name == key.sourceFieldName;
+						});
+
+						if (iter == table.fields.end()) throw std::runtime_error("Primary field inside of table not found. This should not happen?");
+						iter->primary = true;
+
+						continue;
+					}
+
+					key.targetFieldName = keyInfo["referenced_column_name"].get<std::string>();
+					key.targetTableName = keyInfo["referenced_table_name"].get<std::string>();
+
+					table.keys.push_back(key);
+				}
+
+				tables.push_back(table);
+			}
+		}
+
+		bool DatabaseMysql::hasLoadedTables() {
+			return !tables.empty();
+		}
+
+		const MysqlTable& DatabaseMysql::getTable(const std::string& name) {
+			if (tables.empty()) fillTableInfos();
+
+			auto iter = std::find_if(tables.begin(), tables.end(), [&](const MysqlTable& tbl) {
+				return tbl.name == name;
+			});
+
+			if (iter == tables.end()) throw std::runtime_error("Table not found");
+			return *iter;
+		}
+
 		std::vector<std::string> DatabaseMysql::listTables() {
 			auto result = communicator->execute("SHOW TABLES", this);
 			if (!result.success()) return {};

--- a/database/tests/CMakeLists.txt
+++ b/database/tests/CMakeLists.txt
@@ -1,1 +1,2 @@
 ﻿add_subdirectory ("query")
+add_subdirectory ("tableinfo")

--- a/database/tests/tableinfo/CMakeLists.txt
+++ b/database/tests/tableinfo/CMakeLists.txt
@@ -1,0 +1,13 @@
+﻿file(GLOB_RECURSE source_files
+    "src/*.cpp"
+    "src/*.c"
+    "include/*.hpp"
+    "include/*.h"
+)
+
+set(output_target tableInfoTest)
+add_executable(${output_target} ${source_files})
+target_compile_features(${output_target} PRIVATE cxx_std_20)
+target_link_libraries(${output_target} PRIVATE mainframe.networking mainframe.database)
+
+MFAddExecutable(${output_target})

--- a/database/tests/tableinfo/src/main.cpp
+++ b/database/tests/tableinfo/src/main.cpp
@@ -1,0 +1,54 @@
+#include <mainframe/database/mysql/connection.h>
+#include <fmt/printf.h>
+
+using namespace mainframe::database;
+
+int main() {
+	const std::string ip = "127.0.0.1";
+	const int port = 3306;
+	const std::string user = "root";
+	const std::string pass = "";
+
+	ConnectionMysql con;
+	if (!con.connect(ip, port, user, pass)) {
+		fmt::print("failed to connect to database server {}:{} as {}, lastError: {}\n", ip, port, user, con.getLastError());
+		return -1;
+	}
+
+	auto databases = con.listDatabases();
+	if (databases.empty()) {
+		fmt::print("failed to list databases, lastError: {}\n", con.getLastError());
+		return -1;
+	}
+
+	auto db = con.getDatabase(databases.front());
+	auto sqlDb = std::dynamic_pointer_cast<DatabaseMysql>(db);
+
+	auto tables = sqlDb->listTables();
+	if (tables.empty()) {
+		fmt::print("failed to list tables (or database is empty), lastError: {}\n", con.getLastError());
+		return -1;
+	}
+
+	auto& firstTable = sqlDb->getTable(tables.front());
+
+	fmt::print("Table name: `{}`\n", firstTable.name);
+	fmt::print("Table field count: `{}`\n", firstTable.fields.size());
+	fmt::print("{:->{}}\n", "", 96);
+	fmt::print("| {:<16} | {:<16} | {:<16} | {:<16} | {:<16} |\n", "name", "type", "default", "nullable", "is primary");
+	for (auto& field : firstTable.fields) {
+		fmt::print("| {:<16} | {:<16} | {:<16} | {:<16} | {:<16} |\n", field.name, field.type, field.defaultValue, field.nullable, field.primary);
+	}
+	fmt::print("{:->{}}\n", "", 96);
+
+	fmt::print("Table key count: `{}`\n", firstTable.keys.size());
+	fmt::print("{:->{}}\n", "", 93);
+	fmt::print("| {:<32} | {:<16} | {:<16} | {:<16} |\n", "name", "source field", "target table", "target field");
+	for (auto& key : firstTable.keys) {
+		fmt::print("| {:<32} | {:<16} | {:<16} | {:<16} |\n", key.name, key.sourceFieldName, key.targetTableName, key.targetFieldName);
+	}
+	fmt::print("{:->{}}\n", "", 93);
+
+
+	return 0;
+}


### PR DESCRIPTION
This PR adds `TableInfo` to the MySQL database connector with information about `ForeignKeys` and `Fields` inside of tables.

This lets you check if a field is nullable, and has a foreign key. So that you can edit a row with an `size_t` type field as NULL instead of filling in `0` and getting an error.

As example:
```
customer {
  size_t id, UNIQUE
  std::string name
}

// a payment by a customer, or an anonymous payment
payment {
  size_t id, UNIQUE
  size_t customerId, FK -> customer.id, NULLABLE
  size_t amount
}
```
When `customerId` is 0, your code can detect if it should set `NULL` instead of `0`.

On a later stage, the MySQL implementation should have a full scale ORM that deals with this, rather than having to write that code yourself at the moment.
