### PR TITLE
fix dragging of frames

### DIFF
--- a/ui/include/mainframe/ui/scene.h
+++ b/ui/include/mainframe/ui/scene.h
@@ -30,6 +30,7 @@ namespace mainframe {
 			std::shared_ptr<Element> findElement(const std::shared_ptr<Element>& elmPtr, const math::Vector2i& mousePos, const math::Vector2i& offset, math::Vector2i& offsetOut);
 
 			utils::ringbuffer<std::function<void()>> invokes = {64};
+			int pressingMouseButton = 0;
 
 		public:
 

--- a/ui/src/scene.cpp
+++ b/ui/src/scene.cpp
@@ -197,6 +197,8 @@ namespace mainframe {
 
 		void Scene::mousePress(const math::Vector2i& mousePos, unsigned int button, ModifierKey mods, MouseState state) {
 			if (state == MouseState::inactive) {
+				pressingMouseButton--;
+
 				if (focusedElement.expired()) {
 					onMousePress(mousePos, button, mods, state);
 					return;
@@ -212,6 +214,8 @@ namespace mainframe {
 				focused->onMouseUp(mousePos - focused->getPos(), button, mods);
 				return;
 			}
+
+			pressingMouseButton++;
 
 			math::Vector2i offsetOut;
 			auto target = findElement(mousePos, offsetOut);
@@ -235,18 +239,24 @@ namespace mainframe {
 			math::Vector2i offsetOut;
 			auto target = findElement(mousePos, offsetOut);
 
-			// not hovering anything, so send it off to the scene event
-			if (target == nullptr) {
-				// do we have previous element
-				if (!hoveredElement.expired()) {
-					auto elm = hoveredElement.lock();
-					elm->setHovering(false);
+			// were holding our mouse on something, like dragging?
+			if (pressingMouseButton > 0 && !focusedElement.expired()) {
+				target = focusedElement.lock();
+				offsetOut = target->getPosAbsolute();
+			} else {
+				// not hovering anything, so send it off to the scene event
+				if (target == nullptr) {
+					// do we have previous element
+					if (!hoveredElement.expired()) {
+						auto elm = hoveredElement.lock();
+						elm->setHovering(false);
 
-					hoveredElement.reset();
+						hoveredElement.reset();
+					}
+
+					onMouseMove(mousePos);
+					return;
 				}
-
-				onMouseMove(mousePos);
-				return;
 			}
 
 			// see if we're having a different target, if so notify it


### PR DESCRIPTION
When dragging a frame and moving your mouse fast the `onMove` would lose focus and not get events. This lets holding any mouse button override the target so that whatever you clicked will continue to recieve all onMove events until the button is released